### PR TITLE
Remove extra, incorrect digitPins[] description

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ To install, copy the SevSeg folder into your arduino sketchbook\-libraries folde
        ...
 
 
-digitPins is an array that stores the arduino pin numbers that the digits are connected to. Order them from left to right.
 digitPins is an array that stores the arduino pin numbers that the segments are connected to. Order them from segment a to g , then the decimal place.
 If you wish to use more than 8 digits, increase MAXNUMDIGITS in SevSeg.h.
 


### PR DESCRIPTION
I have also made this change on the [SevSeg Arduino Playground page](http://playground.arduino.cc/Main/SevenSegmentLibrary).

Originally reported at: https://github.com/arduino/Arduino/issues/4247