### PR TITLE
use constant expression for digits

### DIFF
--- a/SevSeg.cpp
+++ b/SevSeg.cpp
@@ -426,7 +426,7 @@ void SevSeg::setNumber(float numToShow, char decPlaces, bool hex) { //float
 /******************************************************************************/
 // Changes the number that will be displayed.
 void SevSeg::setNewNum(long numToShow, char decPlaces, bool hex) {
-  byte digits[numDigits];
+  byte digits[MAXNUMDIGITS];
   findDigits(numToShow, decPlaces, hex, digits);
   setDigitCodes(digits, decPlaces);
 }


### PR DESCRIPTION
most compilers will warn against using variables, there is a constant that can be used in place of the variable number of digits. 