### PR TITLE
fixed root-cause of compile errors by chaning data type from bool to …

### DIFF
--- a/SevSeg.cpp
+++ b/SevSeg.cpp
@@ -164,8 +164,18 @@ void SevSeg::begin(byte hardwareConfig, byte numDigitsIn, byte digitPinsIn[],
       break;
   }
 
-  digitOffVal = !digitOnVal;
-  segmentOffVal = !segmentOnVal;
+  // define the Off-Values depending on the On-Values
+  if (digitOnVal == HIGH){
+    digitOffVal = LOW;
+  } else {
+    digitOffVal = HIGH;
+  }
+  // define the Off-Values depending on the On-Values
+  if (segmentOnVal == HIGH){
+    segmentOffVal = LOW;
+  } else {
+    segmentOffVal = HIGH;
+  }
 
   // Save the input pin numbers to library variables
   for (byte segmentNum = 0 ; segmentNum < numSegments ; segmentNum++) {

--- a/SevSeg.h
+++ b/SevSeg.h
@@ -77,7 +77,7 @@ private:
   void digitOn(byte digitNum);
   void digitOff(byte digitNum);
 
-  bool digitOnVal,digitOffVal,segmentOnVal,segmentOffVal;
+  byte digitOnVal,digitOffVal,segmentOnVal,segmentOffVal;
   bool resOnSegments, updateWithDelays, leadingZeros;
   byte digitPins[MAXNUMDIGITS];
   byte segmentPins[8];


### PR DESCRIPTION
…byte(which is uint8_t)

DigitalWrite expects uint8_t (or byte as subsitute) not bool.
This fixes that problem