### PR TITLE
fixing mismatch header/impl

### DIFF
--- a/SevSeg.cpp
+++ b/SevSeg.cpp
@@ -470,7 +470,7 @@ void SevSeg::setSegments(byte segs[]) {
 /******************************************************************************/
 // Displays the string on the display, as best as possible.
 // Only alphanumeric characters plus '-' and ' ' are supported
-void SevSeg::setChars(const char str[]) {
+void SevSeg::setChars(char str[]) {
   for (byte digit = 0; digit < numDigits; digit++) {
     digitCodes[digit] = 0;
   }


### PR DESCRIPTION
Closes #75 

The addition of the `const` keyword here is causing a compile error on Arduino.  Removing the `const` keyword allows it to compile.