### PR TITLE
Prevent against micros() overflowing in refreshDisplay

### DIFF
--- a/SevSeg.cpp
+++ b/SevSeg.cpp
@@ -215,10 +215,10 @@ void SevSeg::refreshDisplay() {
 
     // Exit if it's not time for the next display change
     if (waitOffActive) {
-      if ((int32_t)(us - prevUpdateTime) < waitOffTime) return;
+      if ((us - prevUpdateTime) < waitOffTime) return;
     }
     else {
-      if ((int32_t)(us - prevUpdateTime) < ledOnTime) return;
+      if ((us - prevUpdateTime) < ledOnTime) return;
     }
     prevUpdateTime = us;
 
@@ -446,7 +446,7 @@ void SevSeg::setSegmentsDigit(const uint8_t digitNum, const uint8_t segs) {
 // getSegments
 /******************************************************************************/
 // Gets the 'digitCodes' of currently displayed segments.
-// Using this function, one can get the current set of segments (placed 
+// Using this function, one can get the current set of segments (placed
 // elsewhere) and manipulate them to obtain effects, for example blink of
 // only some digits.
 // See setSegments() for bit-segment mapping

--- a/SevSeg.h
+++ b/SevSeg.h
@@ -38,7 +38,7 @@ public:
 
   void refreshDisplay();
   void begin(uint8_t hardwareConfig, uint8_t numDigitsIn, const uint8_t digitPinsIn[],
-          const uint8_t segmentPinsIn[], bool resOnSegmentsIn=0, 
+          const uint8_t segmentPinsIn[], bool resOnSegmentsIn=0,
           bool updateWithDelaysIn=0, bool leadingZerosIn=0,
 		  bool disableDecPoint=0);
   void setBrightness(int16_t brightnessIn); // A number from 0..100
@@ -70,8 +70,8 @@ private:
   uint8_t prevUpdateIdx; // The previously updated segment or digit
   uint8_t digitCodes[MAXNUMDIGITS]; // The active setting of each segment of each digit
   uint32_t prevUpdateTime; // The time (millis()) when the display was last updated
-  int16_t ledOnTime; // The time (us) to wait with LEDs on
-  int16_t waitOffTime; // The time (us) to wait with LEDs off
+  uint16_t ledOnTime; // The time (us) to wait with LEDs on
+  uint16_t waitOffTime; // The time (us) to wait with LEDs off
   bool waitOffActive; // Whether  the program is waiting with LEDs off
 };
 


### PR DESCRIPTION
Hello,
I have experienced an issue when I don't call refreshDisplay for a while. This issue is caused by a bad timing and an overflow on the function micros() which happens every 70 minutes. This makes prevUpdateTime > us and (int32_t)(us - prevUpdateTime) < waitOffTime could take up to 70 minutes to be false again.
Please merge this PR if you like the fix. 
Other more accurate solution: 
if(us < prevUpdateTime){
    (int32_t)(us + (UINT_TYPE_MAX - prevUpdateTime)) < waitOffTime;
}
but I find it a bit overkill...
Let me know I can update the PR.
Best,
Tom